### PR TITLE
Render resource description and link to model in header

### DIFF
--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -16,7 +16,7 @@ module.exports = env => ({
     './index.js',
   ],
 
-  devtool: 'cheap-module-source-map',
+  devtool: 'source-map',
 
   output: {
     publicPath: '/',

--- a/config/webpack.dev.js
+++ b/config/webpack.dev.js
@@ -16,7 +16,7 @@ module.exports = env => ({
     './index.js',
   ],
 
-  devtool: 'source-map',
+  devtool: 'cheap-module-eval-source-map',
 
   output: {
     publicPath: '/',

--- a/src/application/components/Operation.js
+++ b/src/application/components/Operation.js
@@ -1,11 +1,12 @@
 // @flow
 import React from 'react';
-
+import { Link } from 'react-router';
 import Markdown from '../../components/Markdown';
 import Header from '../components/Header';
 import Request from '../components/Request';
 import Response from '../components/Response';
 import ResourceCard from '../components/ResourceCard';
+import H1 from '../../components/H1';
 
 import type { Operation as OperationType, Service } from '../../generated/version/ServiceType';
 
@@ -23,12 +24,26 @@ const Operation = ({ service, operation, applicationKey, organizationKey, resour
 }) =>
   <div className={styles.content}>
     <div className={styles.header}>
+      <H1 className={styles.h1}>
+        <Link
+          className={styles.link}
+          to={`/org/${organizationKey}/app/${applicationKey}/m/${resource}`}
+        >
+          {resource}
+        </Link>
+      </H1>
+      {operation.resourceDescription && <Markdown
+        source={operation.resourceDescription}
+        className={styles.description}
+      />}
+    </div>
+    <div className={styles.resource}>
       <ResourceCard
         method={operation.method}
         path={operation.path}
       />
     </div>
-    <Markdown source={operation.description ? operation.description : ''} className={styles.description} />
+    {operation.description && <Markdown source={operation.description} className={styles.description} /> }
     <div className={styles.headers}>
       <Header
         appKey={applicationKey}

--- a/src/application/components/operation.css
+++ b/src/application/components/operation.css
@@ -25,6 +25,6 @@
   text-decoration: none;
 
   @nest &:hover {
-    text-decoration: underline;
+    opacity: 0.7
   }
 }

--- a/src/application/components/operation.css
+++ b/src/application/components/operation.css
@@ -4,14 +4,27 @@
   padding: 2rem 0 1rem 0;
 }
 
+.resource {
+  padding: 0 0 1rem 0;
+}
+
 .content {
   padding: 0 3rem;
 }
 
 .description {
-  padding: 0 0 2rem;
+  padding: 1rem 0;
 }
 
 .request {
   padding: 0 0 2rem;
+}
+
+.link {
+  color: inherit;
+  text-decoration: none;
+
+  @nest &:hover {
+    text-decoration: underline;
+  }
 }

--- a/src/application/components/operation.css
+++ b/src/application/components/operation.css
@@ -25,6 +25,6 @@
   text-decoration: none;
 
   @nest &:hover {
-    opacity: 0.7
+    opacity: 0.7;
   }
 }

--- a/src/generated/version/ServiceType.js
+++ b/src/generated/version/ServiceType.js
@@ -107,6 +107,7 @@ export type Operation = {
   body?: Body,
   parameters: Parameter[],
   responses: Response[],
+  resourceDescription?: string,
 };
 
 export type Resource = {

--- a/src/utils.js
+++ b/src/utils.js
@@ -106,7 +106,7 @@ const getOperation = (type: string, method: Method, path: string, service: Servi
   if (!operation) {
     throw new Error(`Operation not found: ${type}`);
   }
-
+  operation.resourceDescription = resource.description;
   return operation;
 };
 


### PR DESCRIPTION
The way I'm doing it changes the resource service type, which would be overwritten if it gets auto generated in the future... alternatively getOperation in utils can return a different type than from ServiceType, or a separate method and call and return the resource description not bound to operation.