### PR TITLE
Fix fail loading of direct URLs beyond App home

### DIFF
--- a/src/application/components/Application.js
+++ b/src/application/components/Application.js
@@ -48,6 +48,9 @@ export class Application extends Component {
   render() {
     const { service, importedServices } = this.props;
 
+    if (!service) {
+      return <LoadingOverlay isLoaded={this.props.loaded} />;
+    }
     if (this.props.params.resource) {
       // Load Operation
       const {


### PR DESCRIPTION
Direct URL loads fail due to null exception of service object
when async sagas are not completed yet. Used to only work
on home page because service is not used on that code path.
Fix renders loading overlay if service is null.