### PR TITLE
document container to remember greatest height

### DIFF
--- a/src/application/components/JsonDoc/Documentation.js
+++ b/src/application/components/JsonDoc/Documentation.js
@@ -1,5 +1,6 @@
 // @flow
-import React from 'react';
+import React, { Component } from 'react';
+import classnames from 'classnames';
 
 import ParameterList from '../ParameterList';
 import * as utils from '../../../utils';
@@ -12,23 +13,57 @@ const defaultView =
     <span className={styles.defaultView}>&lt;-- Hover over JSON example for documentation</span>
   </div>);
 
-const Documentation = ({ documentationFullType, service, importedServices }: {
+type Props = {
   documentationFullType: string,
   service: Service,
   importedServices: Service[],
-}) => {
-  if (!documentationFullType) return defaultView;
-
-  const modelName = documentationFullType.substring(0, documentationFullType.lastIndexOf('.'));
-  const fieldName = documentationFullType.substring(documentationFullType.lastIndexOf('.') + 1);
-  const model = utils.getModel(modelName, service, importedServices);
-  const field = model ? model.fields.find(f => f.name === fieldName) : null;
-
-  return (
-    <div className={styles.documentation}>
-      <ParameterList {...field} service={service} importedServices={importedServices} parentModel={modelName} />
-    </div>
-  );
 };
+
+class Documentation extends Component {
+  props: Props;
+  state: {
+    height: number,
+  };
+  constructor(props: props) {
+    super(props);
+    this.state = { height: 0 };
+    this.updateContainerHeight = this.updateContainerHeight.bind(this);
+  }
+
+  componentDidUpdate() {
+    this.updateContainerHeight();
+  }
+
+  updateContainerHeight() {
+    const container = this.container;
+    if (container) {
+      const height = container.clientHeight;
+      if (height > this.state.height) {
+        this.setState({ height });
+      }
+    }
+  }
+
+  render() {
+    const { documentationFullType, service, importedServices } = this.props;
+    const { height } = this.state;
+    if (!documentationFullType) return defaultView;
+
+    const modelName = documentationFullType.substring(0, documentationFullType.lastIndexOf('.'));
+    const fieldName = documentationFullType.substring(documentationFullType.lastIndexOf('.') + 1);
+    const model = utils.getModel(modelName, service, importedServices);
+    const field = model ? model.fields.find(f => f.name === fieldName) : null;
+
+    return (
+      <div
+        ref={(el) => { this.container = el; }}
+        className={classnames(styles.documentation)}
+        style={{ minHeight: `${height}px` }}
+      >
+        <ParameterList {...field} service={service} importedServices={importedServices} parentModel={modelName} />
+      </div>
+    );
+  }
+}
 
 export default Documentation;

--- a/src/application/components/JsonDoc/Documentation.js
+++ b/src/application/components/JsonDoc/Documentation.js
@@ -28,7 +28,6 @@ class Documentation extends Component {
   constructor(props: Props) {
     super(props);
     this.state = { height: 0 };
-    this.updateContainerHeight = this.updateContainerHeight.bind(this);
   }
 
   componentDidUpdate() {
@@ -36,9 +35,8 @@ class Documentation extends Component {
   }
 
   container: HTMLDivElement;
-  updateContainerHeight: () => void;
 
-  updateContainerHeight() {
+  updateContainerHeight = (): void => {
     const container = this.container;
     if (container) {
       const height = container.clientHeight;
@@ -46,7 +44,7 @@ class Documentation extends Component {
         this.setState({ height });
       }
     }
-  }
+  };
 
   render() {
     const { documentationFullType, service, importedServices } = this.props;

--- a/src/application/components/JsonDoc/Documentation.js
+++ b/src/application/components/JsonDoc/Documentation.js
@@ -24,7 +24,8 @@ class Documentation extends Component {
   state: {
     height: number,
   };
-  constructor(props: props) {
+
+  constructor(props: Props) {
     super(props);
     this.state = { height: 0 };
     this.updateContainerHeight = this.updateContainerHeight.bind(this);
@@ -33,6 +34,9 @@ class Documentation extends Component {
   componentDidUpdate() {
     this.updateContainerHeight();
   }
+
+  container: HTMLDivElement;
+  updateContainerHeight: () => void;
 
   updateContainerHeight() {
     const container = this.container;


### PR DESCRIPTION
Fixes a documentation component hover UI bug when a json doc is rendered at the bottom
of the page. The bug is caused by the height of the component being
dynamic based on content, which extends or contracts the page overall
height. To reproduce, go to https://api-doc.movio.co/org/movio.cinema/app/item/m/Item, scroll completely to bottom of page and hover over json document.

This fix refactors the stateless document component to a stateful component that remembers and re-renders the max previous height.